### PR TITLE
Fix phone lookup to exclude deleted customers

### DIFF
--- a/Infrastructure/Repositories/CustomerRepository.cs
+++ b/Infrastructure/Repositories/CustomerRepository.cs
@@ -102,7 +102,7 @@ public class CustomerRepository : ICustomerRepository
         return await _context.Customers
             .Include(c => c.Branch)
             .Include(c => c.CustomerAssignedToUser)
-            .FirstOrDefaultAsync(c => c.CustomerContact == phone && c.IsActive && c.IsDeleted);
+            .FirstOrDefaultAsync(c => c.CustomerContact == phone && c.IsActive && !c.IsDeleted);
     }
 
     public async Task<List<CustomerCountByUserDto>> GetCountGroupedByCreatedByAsync(int branchId)


### PR DESCRIPTION
## Summary
- ensure `FindByPhoneAsync` doesn't return deleted customers

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503a4292c0833098b874f2edcafd6f